### PR TITLE
To fix the syntax deprecation warnings for macOS

### DIFF
--- a/rclone-manager/rclone-manager.rb.template
+++ b/rclone-manager/rclone-manager.rb.template
@@ -12,7 +12,7 @@ cask "rclone-manager" do
   name "RClone Manager"
   desc "GUI for rclone built with Angular and Tauri"
   homepage "https://github.com/Zarestia-Dev/rclone-manager"
-  depends_on macos: ">= :ventura" # macOS 13
+  depends_on macos: :ventura # macOS 13
   postflight do
     system "/usr/bin/xattr", "-rd", "com.apple.quarantine", "#{appdir}/RClone Manager.app"
   end


### PR DESCRIPTION
To fix #2 again.
I realized that changes should not be made to files under `Casks`. Those files are automatically generated, and the changes to those files would be erased after an update.