### PR TITLE
Fix macOS dependency syntax for RClone Manager

### DIFF
--- a/Casks/rclone-manager@0.2.3.rb
+++ b/Casks/rclone-manager@0.2.3.rb
@@ -12,7 +12,7 @@ cask "rclone-manager@0.2.3" do
   name "RClone Manager"
   desc "GUI for rclone built with Angular and Tauri"
   homepage "https://github.com/Zarestia-Dev/rclone-manager"
-  depends_on macos: ">= :ventura" # macOS 13
+  depends_on macos: :ventura # macOS 13
   postflight do
     system "/usr/bin/xattr", "-rd", "com.apple.quarantine", "#{appdir}/RClone Manager.app"
   end

--- a/Casks/rclone-manager@0.2.4.rb
+++ b/Casks/rclone-manager@0.2.4.rb
@@ -12,7 +12,7 @@ cask "rclone-manager@0.2.4" do
   name "RClone Manager"
   desc "GUI for rclone built with Angular and Tauri"
   homepage "https://github.com/Zarestia-Dev/rclone-manager"
-  depends_on macos: ">= :ventura" # macOS 13
+  depends_on macos: :ventura # macOS 13
   postflight do
     system "/usr/bin/xattr", "-rd", "com.apple.quarantine", "#{appdir}/RClone Manager.app"
   end

--- a/Casks/rclone-manager@0.2.5.rb
+++ b/Casks/rclone-manager@0.2.5.rb
@@ -12,7 +12,7 @@ cask "rclone-manager@0.2.5" do
   name "RClone Manager"
   desc "GUI for rclone built with Angular and Tauri"
   homepage "https://github.com/Zarestia-Dev/rclone-manager"
-  depends_on macos: ">= :ventura" # macOS 13
+  depends_on macos: :ventura # macOS 13
   postflight do
     system "/usr/bin/xattr", "-rd", "com.apple.quarantine", "#{appdir}/RClone Manager.app"
   end

--- a/Casks/rclone-manager@0.2.6.rb
+++ b/Casks/rclone-manager@0.2.6.rb
@@ -12,7 +12,7 @@ cask "rclone-manager@0.2.6" do
   name "RClone Manager"
   desc "GUI for rclone built with Angular and Tauri"
   homepage "https://github.com/Zarestia-Dev/rclone-manager"
-  depends_on macos: ">= :ventura" # macOS 13
+  depends_on macos: :ventura # macOS 13
   postflight do
     system "/usr/bin/xattr", "-rd", "com.apple.quarantine", "#{appdir}/RClone Manager.app"
   end

--- a/Casks/rclone-manager@0.2.7.rb
+++ b/Casks/rclone-manager@0.2.7.rb
@@ -12,7 +12,7 @@ cask "rclone-manager@0.2.7" do
   name "RClone Manager"
   desc "GUI for rclone built with Angular and Tauri"
   homepage "https://github.com/Zarestia-Dev/rclone-manager"
-  depends_on macos: ">= :ventura" # macOS 13
+  depends_on macos: :ventura # macOS 13
   postflight do
     system "/usr/bin/xattr", "-rd", "com.apple.quarantine", "#{appdir}/RClone Manager.app"
   end

--- a/Casks/rclone-manager@0.2.9.rb
+++ b/Casks/rclone-manager@0.2.9.rb
@@ -12,7 +12,7 @@ cask "rclone-manager@0.2.9" do
   name "RClone Manager"
   desc "GUI for rclone built with Angular and Tauri"
   homepage "https://github.com/Zarestia-Dev/rclone-manager"
-  depends_on macos: ">= :ventura" # macOS 13
+  depends_on macos: :ventura # macOS 13
   postflight do
     system "/usr/bin/xattr", "-rd", "com.apple.quarantine", "#{appdir}/RClone Manager.app"
   end


### PR DESCRIPTION
When `brew tap` the Homebrew repository, older RClone Manager versions still have the old syntax and a lot of warnings is shown on the screen. Since Homebrew is still supported for Catalina and later, the new syntax shouldn't be an issue for legacy macOS users.